### PR TITLE
Minor fix for Squeak 6, extend baseline with new install target

### DIFF
--- a/packages/BaselineOfStatisticsWorkbench.package/BaselineOfStatisticsWorkbench.class/instance/baseline..st
+++ b/packages/BaselineOfStatisticsWorkbench.package/BaselineOfStatisticsWorkbench.class/instance/baseline..st
@@ -13,5 +13,6 @@ baseline: spec
 				yourself.
 			spec
 				group: 'default' with: #('StatisticsWorkbench-Core'  'StatisticsWorkbench-Exceptions' 'StatisticsWorkbench-Diagrams');
+				group: 'examples' with: #('default' 'StatisticsWorkbench-Examples');
 				group: 'tests' with: #('StatisticsWorkbench-Tests')];
 				yourself

--- a/packages/BaselineOfStatisticsWorkbench.package/BaselineOfStatisticsWorkbench.class/methodProperties.json
+++ b/packages/BaselineOfStatisticsWorkbench.package/BaselineOfStatisticsWorkbench.class/methodProperties.json
@@ -2,4 +2,4 @@
 	"class" : {
 		 },
 	"instance" : {
-		"baseline:" : "ek 5/24/2019 11:06" } }
+		"baseline:" : "tobe 4/18/2020 08:54" } }

--- a/packages/StatisticsWorkbench-Diagrams.package/SWDiagram.class/instance/initialize.st
+++ b/packages/StatisticsWorkbench-Diagrams.package/SWDiagram.class/instance/initialize.st
@@ -2,7 +2,6 @@ initialization
 initialize
 
 	super initialize.
-	self 
-		color: MenuMorph menuColor; 
+	self
 		charts: OrderedCollection new;
 		applyColorTheme: SWDefaultTheme new.

--- a/packages/StatisticsWorkbench-Diagrams.package/SWDiagram.class/methodProperties.json
+++ b/packages/StatisticsWorkbench-Diagrams.package/SWDiagram.class/methodProperties.json
@@ -23,7 +23,7 @@
 		"extent:" : "Kenneth-Schroeder 6/15/2018 11:58",
 		"hasChart" : "FG 7/24/2019 11:25",
 		"hasCoordinateSystem" : "J.R. 7/29/2017 18:13",
-		"initialize" : "FG 6/12/2019 09:02",
+		"initialize" : "tobe 4/18/2020 15:02",
 		"remove:" : "J.R. 7/29/2017 17:49",
 		"removeChart:" : "Kenneth-Schroeder 6/15/2018 12:16",
 		"removeCoordinateSystem" : "Kenneth-Schroeder 6/15/2018 12:16",


### PR DESCRIPTION
- menuColor has been deprecated and removed, use the morph's default color instead
- add an install group that includes examples to the metacello baseline